### PR TITLE
Add query to find all byte ordering macro invocations in C/C++ code.

### DIFF
--- a/7_macro_invocations.ql
+++ b/7_macro_invocations.ql
@@ -1,1 +1,8 @@
+import cpp
 
+// Just intellisensed and tried different classes until I got
+// what I wanted.
+from Macro m, MacroAccess ma
+where m.getName().regexpMatch("ntoh.*")
+    and ma.getMacro() = m
+select ma, "Byte ordering macro invocation"


### PR DESCRIPTION
This PR fulfills step 7 of the tutorial.